### PR TITLE
gradle overhaul

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,65 +1,189 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        maven {
+            name = "Forge"
+            url = "http://files.minecraftforge.net/maven"
+        }
+        maven {
+            name = "Sonatype"
+            url = 'https://oss.sonatype.org/content/groups/public'
+        }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
+
+plugins {
+    id 'com.matthewprenger.cursegradle' version '1.0.9'
+}
+
 apply plugin: 'net.minecraftforge.gradle.forge'
-//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
+//Only edit below this line, the above code adds and enables the nessasary things for Forge to be setup.
 
+def username = "${mod_name}"
+if (project.hasProperty('dev_mail')) {
+    username = "${dev_mail}"
+}
+else if(project.hasProperty('dev_username')) {
+    username = "${dev_username}"
+}
 
-version = "1.0"
-group = "com.yourname.modid" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "modid"
+version = "${project.mc_version}-${project.mod_version}"
+group= project.base_package // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+//noinspection GroovyUnusedAssignment
+archivesBaseName = project.mod_name
 
-sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = project.jvm_version // Need this here so eclipse task generates correctly.
 compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
+    sourceCompatibility = targetCompatibility = project.jvm_version
+}
+
+repositories {
+    maven {
+        //JEI files
+        //Mantle
+        url = "http://dvs1.progwml6.com/files/maven"
+    }
+    maven {
+        // location of a maven mirror for JEI files, as a fallback
+        name = "ModMaven"
+        url = "http://modmaven.k-4u.nl"
+    }
+
+    maven {
+        //fallback for almost everything, this is CurseForge :P
+        name = "CurseForge"
+        url = "https://minecraft.curseforge.com/api/maven/"
+    }
+
+    maven {
+        name = "JitPack"
+        url = "https://jitpack.io"
+    }
 }
 
 minecraft {
-    version = "1.12.2-14.23.1.2556"
-    runDir = "run"
+    version = "${project.mc_version}-${project.forge_version}"
+    if(file('../run').exists()) {
+		runDir = "../run"
+	}
+	else
+	{
+		runDir = "run"
+	}
     
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
-    // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
-    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+    mappings = project.forge_mappings
+    makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+	
+	replace "@VERSION@", project.mod_version
+    def fingerPrintKey = project.hasProperty('public_key') ? findProperty('public_key').replace(":", "").toLowerCase(Locale.ROOT) : "undefined"
+    replace "@FINGERPRINTKEY@", fingerPrintKey
+    replaceIn "xyz/poketech/elementalconjuring/ElementalConjuring.java"
+
+    //auto-configure the run arguments
+    clientRunArgs += "--username=${username}"
+    if(project.hasProperty('dev_password')) {
+        clientRunArgs += "--password=${dev_password}"
+    }
+    serverRunArgs += "nogui" //mc server GUIs suck :P
+
+    serverJvmArgs += "-Dfml.queryResult=confirm"
+}
+
+sourceSets {
+	
+	main {
+		java {
+			srcDir 'src/main/java'
+		}
+		resources {
+			srcDir 'resources'
+		}
+	}
+}
+
+jar {
+    manifest.mainAttributes(
+            "Implementation-Title": project.name,
+            "Implementation-Version": "${project.mod_version}",
+            "Built-On": "${project.mc_version}-${project.forge_version}",
+            "FMLAT": "${project.mod_name}_at.cfg"
+    )
+}
+
+task signJar(type: SignJar, dependsOn: reobfJar) {
+    onlyIf {
+        project.hasProperty('sign_keyStore')
+    }
+    keyPass = findProperty('sign_keyPass')
+    keyStore = findProperty('sign_keyStore')
+    storePass = findProperty('sign_storePass')
+    alias = findProperty('sign_alias')
+
+    inputFile = jar.archivePath
+    outputFile = jar.archivePath
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
 }
 
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
 
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    //compile against the JEI api
+    //compile "mezz.jei:jei_${project.mc_version}:${project.jei_version}:api"
 
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    //JEI (not required)
+    runtime "mezz.jei:jei_${project.mc_version}:${project.jei_version}"
 
 }
+tasks.build.dependsOn signJar
+tasks.curseforge.dependsOn build
 
-processResources {
+def curseRelations = {
+    //optionalLibrary '' //add curseforge-slug here
+}
+
+
+curseforge {
+    if (project.hasProperty('curse_key'))
+        apiKey = project.curse_key
+
+    if(project.hasProperty('curse_id')) {
+        project {
+            id = project.curse_id
+            changelogType = 'markdown'
+            changelog = getChangelogText()
+            releaseType = project.release_type
+
+            relations curseRelations
+
+            //no such jars for now
+            //addArtifact javadocJar
+            //addArtifact sourceJar
+            //addArtifact apiJar
+
+            addGameVersion '1.12'
+            addGameVersion '1.12.1'
+            addGameVersion '1.12.2'
+
+            mainArtifact(jar) {
+                displayName = "Elemental Conjuring v${project.mod_version} MC${project.mc_version}"
+            }
+        }
+    }
+}
+
+processResources
+{
     // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
+    inputs.property "version", version
     inputs.property "mcversion", project.minecraft.version
 
     // replace stuff in mcmod.info, nothing else
@@ -67,11 +191,44 @@ processResources {
         include 'mcmod.info'
                 
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version':version, 'mcversion':project.minecraft.version
     }
         
-    // copy everything else except the mcmod.info
+    // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
+	
+	//ATs
+	rename '(.+_at.cfg)', 'META-INF/$1'
+}
+
+String getChangelogText() {
+    def changelogFile = new File(project.projectDir, "changelog.md")
+    String str = ''
+    if(!changelogFile.exists()) {
+        changelogFile.createNewFile()
+        return str
+    }
+    String separator = '---'
+    int lineCount = 0
+    boolean done = false
+    changelogFile.eachLine {
+        if (done || it == null) {
+            return
+        }
+        if (lineCount < 3) {
+            lineCount++
+            if (it.startsWith(separator)) {
+                return
+            }
+        }
+        if (!it.startsWith(separator)) {
+            str += "$it" + (lineCount < 3 ? ':\n\n' : '\n')
+            return
+        }
+        done = true // once we go past the first version block, parse no more
+    }
+    str += "\n\n see full changelog [here](${project.changelog_url} \"Changelog\")"
+    return str
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,8 @@ sourceSets {
 }
 
 jar {
+    exclude('xyz/poketech/elementalconjuring/debug/**')
+
     manifest.mainAttributes(
             "Implementation-Title": project.name,
             "Implementation-Version": "${project.mod_version}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,19 @@
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+#general
+    mod_name = elemental-conjuring
+    base_package = xyz.poketech.elementalconjuring
+    
+#forge
+    mc_version = 1.12.2
+    mod_version = 0.1.0
+    forge_version = 14.23.1.2555
+    forge_mappings = snapshot_20171225
+    jvm_version = 1.8
+
+#curseforge
+    #curse_id =
+    changelog_url = https://github.com/UpcraftLP/Colorful-Sheep/blob/1.12.X/changelog.md
+    release_type = alpha
+
+#dependencies
+    #jei:
+        jei_version = 4.8.5.138

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 
 #curseforge
     #curse_id =
-    changelog_url = https://github.com/UpcraftLP/Colorful-Sheep/blob/1.12.X/changelog.md
+    changelog_url = https://github.com/Poke1650/Elemental-Conjuring/blob/1.12.X/changelog.md
     release_type = alpha
 
 #dependencies

--- a/src/main/java/xyz/poketech/elementalconjuring/ElementalConjuring.java
+++ b/src/main/java/xyz/poketech/elementalconjuring/ElementalConjuring.java
@@ -12,11 +12,20 @@ import xyz.poketech.elementalconjuring.proxy.CommonProxy;
  * Created by Poke on 2017-11-21.
  */
 @Mod.EventBusSubscriber
-@Mod(modid = ElementalConjuring.MODID, version = ElementalConjuring.VERSION)
+@Mod(
+        modid = ElementalConjuring.MODID,
+        version = ElementalConjuring.VERSION,
+        acceptedMinecraftVersions = ElementalConjuring.VERSION_RANGE,
+        dependencies = ElementalConjuring.DEPENDENCIES,
+        certificateFingerprint = ElementalConjuring.FINGERPRINT_KEY
+)
 public class ElementalConjuring
 {
     public static final String MODID = "elemental_conjuring";
-    public static final String VERSION = "1.0";
+    public static final String VERSION = "@VERSION@";
+    public static final String FINGERPRINT_KEY = "@FINGERPRINTKEY@";
+    public static final String VERSION_RANGE = "[1.12,1.13)";
+    public static final String DEPENDENCIES = "required-after:forge@[14.13.0.2489,)";
 
     @Mod.Instance
     public static ElementalConjuring instance;

--- a/src/main/java/xyz/poketech/elementalconjuring/debug/DebugEvents.java
+++ b/src/main/java/xyz/poketech/elementalconjuring/debug/DebugEvents.java
@@ -1,4 +1,4 @@
-package xyz.poketech.elementalconjuring;
+package xyz.poketech.elementalconjuring.debug;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Items;
@@ -7,6 +7,8 @@ import net.minecraft.util.EnumHand;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import xyz.poketech.elementalconjuring.ElementalConjuring;
+import xyz.poketech.elementalconjuring.ModItems;
 import xyz.poketech.elementalconjuring.entities.EntitySummonedItem;
 import xyz.poketech.elementalconjuring.data.ElementType;
 


### PR DESCRIPTION
- downgraded forge to 1.12.2 recommended build (14.23.1.2556 --> 14.23.1.2555)
- moved debug events class to dedicated package (`xyz.poketech.elementalconjuring.debug`) and excluded the package from exporting into jar
- added JEI as workspace runtime dependency, this will have no effects on the mod itself, it's only for easier testing and can be disabled (version: 4.8.5.138)
- prepared for jar signing, if a keystore is present as `sign_keyStore`.
- added cursegradle plugin for uploading build artifacts to curseforge. (version range: 1.12-1.12.2, release type: alpha)
- marked mod for Minecraft version range `[1.12,1.13)`

---
None of the above changes will be visible ingame, except for JEI and the debug classes not being present when exporting the mod.